### PR TITLE
Add avahi zeroconf support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,7 +16,8 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
+  - name: debian-8.6
+  - name: debian-9.0
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,8 +16,7 @@ verifier:
   name: inspec
 
 platforms:
-  - name: debian-8.6
-  - name: debian-9.0
+  - name: ubuntu-16.04
 
 suites:
   - name: default
@@ -47,3 +46,21 @@ suites:
             host:
               name: 'tincvpn3'
               address: "15.0.0.16"
+
+  - name: avahi_zeroconf
+    run_list:
+      - recipe[tincvpn::default]
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              name: 'tincvpn3'
+              address: "15.0.0.16"
+              avahi_zeroconf_enabled: true
+              subnets:
+                - '10.3.0.0/24'
+                - '172.3.0.0/16'
+              connect_to:
+                - 'tincnode1'
+                - 'tincnode2'

--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -14,3 +14,8 @@ default[:tincvpn][:networks]['default'][:host][:connect_to] = []
 default[:tincvpn][:networks]['default'][:host][:subnets] = []
 # will default to fqdn when not set
 default[:tincvpn][:networks]['default'][:host][:address] = nil
+
+# use zeroconf with automatic ip and dns management
+# see https://www.tinc-vpn.org/examples/zeroconf-ip-and-dns/ for details
+
+default[:tincvpn][:networks]['default'][:host][:avahi_zeroconf_enabled] = false

--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -16,6 +16,6 @@ default[:tincvpn][:networks]['default'][:host][:subnets] = []
 default[:tincvpn][:networks]['default'][:host][:address] = nil
 
 # use zeroconf with automatic ip and dns management
-# see https://www.tinc-vpn.org/examples/zeroconf-ip-and-dns/ for details
-
+# see https://www.tinc-vpn.org/examples/zeroconf-ip-and-dns/ for details.
+# When using this option network mode always switch and subnets are always empty array
 default[:tincvpn][:networks]['default'][:host][:avahi_zeroconf_enabled] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'eugen.mayer@kontextwork.de'
 license          'Apache 2.0'
 description      'Tinc Virtual Private Network'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.1.9'
+version           '0.1.10'
 chef_version      '>= 13'
 
 %w[ ubuntu debian ].each do |os|

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'eugen.mayer@kontextwork.de'
 license          'Apache 2.0'
 description      'Tinc Virtual Private Network'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.1.10'
+version           '0.1.9'
 chef_version      '>= 13'
 
 %w[ ubuntu debian ].each do |os|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -153,6 +153,6 @@ template '/etc/tinc/nets.boot' do
   variables(
     networks: node['tincvpn']['networks'].keys
   )
-  notifies :restart, 'service[tinc]', :delayed
+  notifies :restart, 'service[tinc]', :immediately
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 
+
 package %w(tinc bridge-utils)
 # prepared for later multi-network per host deployments, not implemented yet
 
@@ -19,13 +20,24 @@ end
 # so they can actually connect to each other
 node['tincvpn']['networks'].each do |network_name, network|
   raise "You need to set the host name for the tinc network #{network_name} in ['tincvpn']['networks'][#{network_name}]['network']['host']['name']" if network['host']['name'].nil?
-  raise 'You defined siwtch as you mode, but also defined subnets - this is now allowed by tinc' if !node['tincvpn']['networks'][network_name]['host']['subnets'].empty? && network['network']['mode'] == 'switch'
+  raise 'You defined switch as you mode, but also defined subnets - this is now allowed by tinc' if !node['tincvpn']['networks'][network_name]['host']['subnets'].empty? && network['network']['mode'] == 'switch'
 
   directory "/etc/tinc/#{network_name}"
   directory "/etc/tinc/#{network_name}/hosts"
   local_host_name = node['tincvpn']['networks'][network_name]['host']['name']
   local_host_path = "/etc/tinc/#{network_name}/hosts/#{local_host_name}"
   priv_key_location = "/etc/tinc/#{network_name}/rsa_key.priv"
+
+  avahi_zeroconf_enabled = node['tincvpn']['networks'][network_name]['host']['avahi_zeroconf_enabled']
+
+  if avahi_zeroconf_enabled
+    package %w(avahi-daemon avahi-utils avahi-autoipd)
+
+    service 'avahi-daemon' do
+      action [ :enable, :start ]
+    end
+  end
+
 
   # we use the tinc tool to generate the priv and public key, since openssl with public key is kind of complicated with chef
   # we remove the tinc.conf before we generate, since otherwise the public key will not be saved in /etc/tinc/#{network_name}/rsa_key.pub
@@ -47,7 +59,7 @@ node['tincvpn']['networks'].each do |network_name, network|
       pub_key: lazy { File.read("/etc/tinc/#{network_name}/rsa_key.pub") },
       address: host_addr,
       port: node['tincvpn']['networks'][network_name]['network']['port'],
-      subnets: node['tincvpn']['networks'][network_name]['host']['subnets']
+      subnets: avahi_zeroconf_enabled ? [] : node['tincvpn']['networks'][network_name]['host']['subnets']
     )
   end
 
@@ -67,6 +79,7 @@ node['tincvpn']['networks'].each do |network_name, network|
       variables(
         tunnel_address: network['network']['tunneladdr'],
         tunnel_netmask: network['network']['tunnelnetmask'],
+        avahi_zeroconf_enabled: avahi_zeroconf_enabled
       )
       notifies :reload, 'service[tinc]', :delayed
     end
@@ -102,11 +115,11 @@ node['tincvpn']['networks'].each do |network_name, network|
         address: host_addr,
         pub_key: host_pubkey,
         port: peer['tincvpn']['networks'][network_name]['network']['port'],
-        subnets: peer['tincvpn']['networks'][network_name]['host']['subnets']
+        subnets: avahi_zeroconf_enabled ? [] : peer['tincvpn']['networks'][network_name]['host']['subnets']
       )
       notifies :reload, 'service[tinc]', :delayed
     end
-    
+
     # add all hosts to our connectTo list, except ourselfs
     hosts_connect_to << host_name
   end
@@ -120,7 +133,7 @@ node['tincvpn']['networks'].each do |network_name, network|
       name: network['host']['name'],
       port: network['network']['port'],
       hosts_connect_to: hosts_connect_to,
-      mode: network['network']['mode']
+      mode: avahi_zeroconf_enabled ? 'switch' : network['network']['mode']
     )
     notifies :reload, 'service[tinc]', :delayed
   end

--- a/templates/tinc-up.erb
+++ b/templates/tinc-up.erb
@@ -1,3 +1,6 @@
 #!/bin/sh
-
-ifconfig $INTERFACE <%=@tunnel_address%> netmask <%=@tunnel_netmask%>
+<% if @avahi_zeroconf_enabled %>
+avahi-autoipd --daemonize --wait $INTERFACE
+<% else %>
+ifconfig $INTERFACE <%= @tunnel_address%> netmask <%=@tunnel_netmask %>
+<% end %>

--- a/test/integration/avahi_zeroconf/tinc_spec.rb
+++ b/test/integration/avahi_zeroconf/tinc_spec.rb
@@ -1,0 +1,73 @@
+describe package('tinc') do
+  it { should be_installed }
+end
+
+describe package('avahi-daemon') do
+  it { should be_installed }
+end
+
+describe package('avahi-autoipd') do
+  it { should be_installed }
+end
+
+describe file('/etc/tinc/default/tinc.conf') do
+  it { should exist }
+  its('content') { should match "Port = 655" }
+  its('content') { should match "ConnectTo = tincnode1" }
+  its('content') { should match "ConnectTo = tincnode2" }
+  its('content') { should_not match "ConnectTo = tincnode4" }
+  its('content') { should match "Mode = switch" }
+  its('content') { should match "Name = tincvpn3" }
+end
+
+describe file('/etc/tinc/default/tinc-up') do
+  it { should exist }
+  its('content') { should match "avahi-autoipd --daemonize --wait [$]INTERFACE" }
+  its('content') { should_not match "ifconfig" }
+end
+
+describe file('/etc/tinc/default/tinc-down') do
+  it { should exist }
+  its('content') { should match "ifconfig [$]INTERFACE down" }
+end
+
+describe file('/etc/tinc/default/rsa_key.priv') do
+  it { should exist }
+  its('size') { should > 0 }
+end
+
+describe file('/etc/tinc/default/rsa_key.pub') do
+  it { should exist }
+  its('size') { should > 0 }
+end
+
+describe file('/etc/tinc/default/hosts/tincnode1') do
+  it { should exist }
+  its('content') { should match "Address = 15\.0\.0\.1 651" }
+  its('content') { should_not match "10\.1\.0\.0/24" }
+  its('content') { should_not match "172\.1\.0\.0/16" }
+  its('content') { should match "test-pubkey1" }
+end
+
+describe file('/etc/tinc/default/hosts/tincnode2') do
+  it { should exist }
+  its('content') { should match "Address = 15\.0\.0\.2 652" }
+  its('content') { should_not match "10\.2\.0\.0/24" }
+  its('content') { should_not match "172\.2\.0\.0/16" }
+  its('content') { should match "test-pubkey2" }
+end
+
+# we excluded that one in our attributes
+describe file('/etc/tinc/default/hosts/tincnode4') do
+  it { should_not exist }
+end
+
+# thats our own host
+describe file('/etc/tinc/default/hosts/tincvpn3') do
+  it { should exist }
+  its('content') { should match "Address = 15\.0\.0\.16 655" }
+  its('content') { should_not match "10\.3\.0\.0/24" }
+  its('content') { should_not match "172\.3\.0\.0/16" }
+  its('content') { should match 'BEGIN RSA PUBLIC KEY'}
+  its('content') { should match 'END RSA PUBLIC KEY'}
+end


### PR DESCRIPTION
There is option to use avahi for automatic ip and DNS management described in  https://www.tinc-vpn.org/examples/zeroconf-ip-and-dns/. This merge request allow use this configuration by adding attrubute `avahi_zeroconf_enabled`.