### PR TITLE
Added an Interface setting for tinc.conf

### DIFF
--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -3,6 +3,8 @@
 # mode is either router, switch or hub, see https://www.tinc-vpn.org/documentation/tinc.conf.5
 default[:tincvpn][:networks]['default'][:network][:mode] = 'router'
 default[:tincvpn][:networks]['default'][:network][:port] = 655
+# Set interface if needed
+default[:tincvpn][:networks][:default][:network][:interface] = nill  # Ex. 'tun'
 # that is the virtual network the tinc mesh nodes connect to (not your LAN you will join/offer, see subnets)
 default[:tincvpn][:networks]['default'][:network][:tunneladdr] = '172.25.0.1'
 default[:tincvpn][:networks]['default'][:network][:tunnelnetmask] = '255.255.255.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -132,6 +132,7 @@ node['tincvpn']['networks'].each do |network_name, network|
     variables(
       name: network['host']['name'],
       port: network['network']['port'],
+      interface: network['network']['interface'],
       hosts_connect_to: hosts_connect_to,
       mode: avahi_zeroconf_enabled ? 'switch' : network['network']['mode']
     )

--- a/templates/tinc.conf.erb
+++ b/templates/tinc.conf.erb
@@ -2,6 +2,7 @@ Name = <%= @name %>
 AddressFamily = any
 Mode = <%= @mode %>
 Port = <%= @port %>
+<%= 'Interface = ' + @interface if @interface %>
 <% @hosts_connect_to.sort.each do |connect_to| %>
 ConnectTo = <%= connect_to %>
 <% end -%>


### PR DESCRIPTION
This was needed to get tinc to run. Would exit after too many errors.

Running on Ubuntu 16.04
Sample errors:
tincd 1.0.26 (Jul  5 2015 23:17:54) starting, debug level 5
/dev/net/tun is a Linux ethertap device
Executing script tinc-up
SIOCSIFADDR: No such device
tun: ERROR while getting interface flags: No such device
SIOCSIFNETMASK: No such device
Script tinc-up exited with non-zero status 255