### PR TITLE
Corrected spelling error.

### DIFF
--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -4,7 +4,7 @@
 default[:tincvpn][:networks]['default'][:network][:mode] = 'router'
 default[:tincvpn][:networks]['default'][:network][:port] = 655
 # Set interface if needed
-default[:tincvpn][:networks][:default][:network][:interface] = nill  # Ex. 'tun'
+default[:tincvpn][:networks][:default][:network][:interface] = nil  # Ex. 'tun'
 # that is the virtual network the tinc mesh nodes connect to (not your LAN you will join/offer, see subnets)
 default[:tincvpn][:networks]['default'][:network][:tunneladdr] = '172.25.0.1'
 default[:tincvpn][:networks]['default'][:network][:tunnelnetmask] = '255.255.255.0'


### PR DESCRIPTION
I missed a spelling error in the default attributes file.  nil is not spelled nill.