### PR TITLE
Avoids having to set the host name parameter (Closes #8 and #11)

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -4,20 +4,22 @@
 # currently this is not working but it is WIP
 
 driver:
-  name: docker
-  privileged: yes
-  run_command: /bin/systemd
-  provision_command:
-    - apt-get install systemd -y
-  disable_upstart: false
   cap_add:
     - SYS_ADMIN
+  disable_upstart: false
+  hostname: tincvpn3
+  name: docker
+  privileged: yes
+  provision_command:
+    - apt-get install systemd -y
+  run_command: /bin/systemd
   socket: unix:///var/run/docker.sock
+
 provisioner:
-  name: chef_zero
   always_update_cookbooks: true
-  nodes_path: test/fixtures/nodes
   chef_license: accept
+  name: chef_zero
+  nodes_path: test/fixtures/nodes
 
 verifier:
   name: inspec
@@ -29,48 +31,106 @@ platforms:
       image: debian:stretch
 
 suites:
-  - name: default
-    run_list:
-      - recipe[tincvpn::default]
+  - name: default-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
             host:
-              name: 'tincvpn3'
               connect_to:
-                - 'tincnode1'
-                - 'tincnode2'
+                - tincnode1
+                - tincnode2
               subnets:
-                - '10.3.0.0/24'
-                - '172.3.0.0/16'
-  - name: switch
+                - 10.3.0.0/24
+                - 172.3.0.0/16
     run_list:
       - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+  - name: switch-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
+            host:
+              address: 15.0.0.16
             network:
-              mode: "switch"
-            host:
-              name: 'tincvpn3'
-              address: "15.0.0.16"
-
-  - name: avahi-zeroconf
+              mode: switch
     run_list:
       - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/switch
+  - name: avahi-zeroconf-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
             host:
-              name: 'tincvpn3'
-              address: "15.0.0.16"
+              address: 15.0.0.16
               avahi_zeroconf_enabled: true
               subnets:
-                - '10.3.0.0/24'
-                - '172.3.0.0/16'
+                - 10.3.0.0/24
+                - 172.3.0.0/16
               connect_to:
-                - 'tincnode1'
-                - 'tincnode2'
+                - tincnode1
+                - tincnode2
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/avahi_zeroconf
+  - name: default-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              connect_to:
+                - tincnode1
+                - tincnode2
+              name: tincvpn3
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+  - name: switch-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              address: 15.0.0.16
+              name: tincvpn3
+            network:
+              mode: switch
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/switch
+  - name: avahi-zeroconf-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              address: 15.0.0.16
+              avahi_zeroconf_enabled: true
+              connect_to:
+                - tincnode1
+                - tincnode2
+              name: tincvpn3
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/avahi_zeroconf

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -48,6 +48,22 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/default
+  - name: custom-network-without-host-name
+    attributes:
+      tincvpn:
+        networks:
+          custom:
+            host:
+              connect_to:
+                - tinccustomnode1
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/custom_network
   - name: switch-without-host-name
     attributes:
       tincvpn:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -45,6 +45,22 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/default
+  - name: custom-network-without-host-name
+    attributes:
+      tincvpn:
+        networks:
+          custom:
+            host:
+              connect_to:
+                - tinccustomnode1
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/custom_network
   - name: switch-without-host-name
     attributes:
       tincvpn:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,15 +1,15 @@
 ---
 driver:
+  hostname: tincvpn3 # Hostname is used in the tests so should be fixed
   name: dokken
-  #image: debian:stretch # for now avoiding to use dokken/debian-9
   privileged: true  # because Docker and SystemD/Upstart
 
 provisioner:
-  name: dokken
+  always_update_cookbooks: true
   chef_license: accept
   client_rb:
     chef_license: accept
-  always_update_cookbooks: true
+  name: dokken
   nodes_path: test/fixtures/nodes
 
 transport:
@@ -17,59 +17,117 @@ transport:
 
 platforms:
   - name: debian-9.9
-    hostname: tincvpn3 # Hostname is used in the tests so should be fixed
     driver:
       image: debian:stretch
-      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN apt-get install -y systemd
+      pid_one_command: /bin/systemd
 
 verifier:
   name: inspec
 
 suites:
-  - name: default
-    run_list:
-      - recipe[tincvpn::default]
+  - name: default-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
             host:
-              name: 'tincvpn3'
               connect_to:
-                - 'tincnode1'
-                - 'tincnode2'
+                - tincnode1
+                - tincnode2
               subnets:
-                - '10.3.0.0/24'
-                - '172.3.0.0/16'
-  - name: switch
+                - 10.3.0.0/24
+                - 172.3.0.0/16
     run_list:
       - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+  - name: switch-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
+            host:
+              address: 15.0.0.16
             network:
-              mode: "switch"
-            host:
-              name: 'tincvpn3'
-              address: "15.0.0.16"
-  - name: avahi-zeroconf
+              mode: switch
     run_list:
       - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/switch
+  - name: avahi-zeroconf-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
             host:
-              name: 'tincvpn3'
-              address: "15.0.0.16"
+              address: 15.0.0.16
               avahi_zeroconf_enabled: true
-              subnets:
-                - '10.3.0.0/24'
-                - '172.3.0.0/16'
               connect_to:
-                - 'tincnode1'
-                - 'tincnode2'
+                - tincnode1
+                - tincnode2
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/avahi_zeroconf
+  - name: default-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              connect_to:
+                - tincnode1
+                - tincnode2
+              name: tincvpn3
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+  - name: switch-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              address: 15.0.0.16
+              name: tincvpn3
+            network:
+              mode: switch
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/switch
+  - name: avahi-zeroconf-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              address: 15.0.0.16
+              avahi_zeroconf_enabled: true
+              connect_to:
+                - tincnode1
+                - tincnode2
+              name: tincvpn3
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/avahi_zeroconf

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,63 +1,123 @@
 ---
+driver:
+  name: vagrant
+  vm_hostname: tincvpn3
+
+provisioner:
+  always_update_cookbooks: true
+  chef_license: accept
+  name: chef_zero
+  nodes_path: test/fixtures/nodes
+  product_name: chef
+  product_version: 14.12
+
 verifier:
   name: inspec
 
-driver:
-  name: vagrant
-
-provisioner:
-  name: chef_zero
-  always_update_cookbooks: true
-  nodes_path: test/fixtures/nodes
-  product_version: 14.12
-  product_name: chef
-  chef_license: accept
-
 platforms:
-  - name: debian-9.9
+  - name: debian-9.6
 
 suites:
-  - name: default
-    run_list:
-      - recipe[tincvpn::default]
+  - name: default-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
             host:
-              name: 'tincvpn3'
               connect_to:
-                - 'tincnode1'
-                - 'tincnode2'
+                - tincnode1
+                - tincnode2
               subnets:
-                - '10.3.0.0/24'
-                - '172.3.0.0/16'
-  - name: switch
+                - 10.3.0.0/24
+                - 172.3.0.0/16
     run_list:
       - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+  - name: switch-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
+            host:
+              address: 15.0.0.16
             network:
-              mode: "switch"
-            host:
-              name: 'tincvpn3'
-              address: "15.0.0.16"
-  - name: avahi-zeroconf
+              mode: switch
     run_list:
       - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/switch
+  - name: avahi-zeroconf-without-host-name
     attributes:
       tincvpn:
         networks:
           default:
             host:
-              name: 'tincvpn3'
-              address: "15.0.0.16"
+              address: 15.0.0.16
               avahi_zeroconf_enabled: true
-              subnets:
-                - '10.3.0.0/24'
-                - '172.3.0.0/16'
               connect_to:
-                - 'tincnode1'
-                - 'tincnode2'
+                - tincnode1
+                - tincnode2
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/avahi_zeroconf
+  - name: default-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              connect_to:
+                - tincnode1
+                - tincnode2
+              name: tincvpn3
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+  - name: switch-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              address: 15.0.0.16
+              name: tincvpn3
+            network:
+              mode: switch
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/switch
+  - name: avahi-zeroconf-with-host-name
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            host:
+              address: 15.0.0.16
+              avahi_zeroconf_enabled: true
+              connect_to:
+                - tincnode1
+                - tincnode2
+              name: tincvpn3
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/avahi_zeroconf

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,6 +35,22 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/default
+  - name: custom-network-without-host-name
+    attributes:
+      tincvpn:
+        networks:
+          custom:
+            host:
+              connect_to:
+                - tinccustomnode1
+              subnets:
+                - 10.3.0.0/24
+                - 172.3.0.0/16
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/custom_network
   - name: switch-without-host-name
     attributes:
       tincvpn:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ services:
 env:
   - KITCHEN_YAML=.kitchen.dokken.yml
   - KITCHEN_YAML=.kitchen.docker.yml
+
 before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk
 
-install: chef exec bundle install --jobs=3 --retry=3 --without='vagrant'
+install: CHEF_LICENSE=accept chef exec bundle install --jobs=3 --retry=3 --without='vagrant'
 
 before_script: sudo iptables -L DOCKER || sudo iptables -N DOCKER
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gem 'knife-cookbook-doc', '>=0.13.0'
@@ -5,13 +7,13 @@ gem 'knife-cookbook-doc', '>=0.13.0'
 gem 'berkshelf'
 
 group :integration do
-  gem 'test-kitchen'
   gem 'kitchen-inspec'
+  gem 'test-kitchen'
 end
 
 group :vagrant do
-  gem 'vagrant-wrapper'
   gem 'kitchen-vagrant'
+  gem 'vagrant-wrapper'
 end
 
 group :docker do

--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -14,7 +14,7 @@ default[:tincvpn][:networks]['default'][:host][:name] = nil
 default[:tincvpn][:networks]['default'][:host][:connect_to] = []
 # define the subnets you want to share of your networks, like you LAN or whatever
 default[:tincvpn][:networks]['default'][:host][:subnets] = []
-# will default to fqdn when not set
+# will default to the node ipaddress when not set
 default[:tincvpn][:networks]['default'][:host][:address] = nil
 
 # use zeroconf with automatic ip and dns management

--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -4,11 +4,11 @@
 default[:tincvpn][:networks]['default'][:network][:mode] = 'router'
 default[:tincvpn][:networks]['default'][:network][:port] = 655
 # Set interface if needed
-default[:tincvpn][:networks][:default][:network][:interface] = nil  # Ex. 'tun'
+default[:tincvpn][:networks]['default'][:network][:interface] = nil  # Ex. 'tun'
 # that is the virtual network the tinc mesh nodes connect to (not your LAN you will join/offer, see subnets)
 default[:tincvpn][:networks]['default'][:network][:tunneladdr] = '172.25.0.1'
 default[:tincvpn][:networks]['default'][:network][:tunnelnetmask] = '255.255.255.0'
-# mandatory, you need to set this to a name of the host, like node1 or whatever
+# optional, you can to set this to a name of the host, like node1 or whatever
 default[:tincvpn][:networks]['default'][:host][:name] = nil
 # which nodes this host should be able to connect to. If you skip, any node in this network will be a connect target
 default[:tincvpn][:networks]['default'][:host][:connect_to] = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,8 +94,8 @@ node['tincvpn']['networks'].each do |network_name, network|
   # local host entry in hosts/
   # thats basically "us in the hosts file" - this is needed and mandaory
   # Takes the host address from the attributes if defined, otherwise takes
-  # the automatic fqdn attribute (ohai)
-  host_addr = network['host']['address'] || node['fqdn']
+  # the automatic ipaddress attribute (ohai)
+  host_addr = network['host']['address'] || node['ipaddress']
   template local_host_path do
     source 'host.erb'
     variables(
@@ -154,7 +154,7 @@ node['tincvpn']['networks'].each do |network_name, network|
     # (if the whitelist exists)
     next if !Array(defined_connect_to).empty? && !Array(defined_connect_to).include?(host_name)
 
-    host_addr = peer['fqdn']
+    host_addr = peer['ipaddress']
     host_addr = peer['tincvpn']['networks'][network_name]['host']['address'] unless peer['tincvpn']['networks'][network_name]['host']['address'].nil?
     host_pubkey = peer['tincvpn']['networks'][network_name]['host']['pubkey']
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 package %w(tinc bridge-utils)
@@ -7,19 +9,46 @@ service 'tinc' do
   action [ :enable, :start ]
 end
 
-# we want to override the options passed to `tincd` and include the --logfile option
+# We want to override the options passed to `tincd` and include the --logfile
+# option
 template '/etc/default/tinc' do
   source 'tinc.default.erb'
-  mode 0644
+  mode '0644'
   notifies :restart, 'service[tinc]'
 end
 
-# for each tinc network which has been define on that node, create the configuration for each and find all other nodes( peers )
-# using chef-search, which do have the same networks, and create hosts files on this node for those with their public key
-# so they can actually connect to each other
+# Avoids creating the `default` network from default attributes when using a
+# custom network instead.
+# The "default" network alone should not be deleted at all.
+if Array(node['tincvpn']['networks']).size > 1
+  default_network = node['tincvpn']['networks']['default']
+  if default_network # If there is a "default" network in the attributes
+    avahi_enabled = default_network['host'] && \
+                    default_network['host']['avahi_zeroconf_enabled'] \
+                    || false
+    default_host_subnets = Array(default_network['host']['subnets'])
+    # Removes the "default" network if it exists, is not alone, and
+    # has the Avahi to false and the subnets is empty
+    if avahi_enabled == false && default_host_subnets.empty?
+      Chef::Log.warn 'Removing the "default" network from attributes has ' \
+                     "it doesn't seem to be used."
+      node.rm('tincvpn', 'networks', 'default')
+    end
+  end
+end
+
+# For each tinc network which has been define on that node,
+# create the configuration for each and find all other nodes( peers ) using
+# chef-search, which do have the same networks, and create hosts files
+# on this node for those with their public key so they can actually connect
+# to each other
 node['tincvpn']['networks'].each do |network_name, network|
-  if !Array(network['host']['subnets']).empty? && network['network'] && network['network']['mode'] == 'switch'
-    raise 'You defined switch as your mode, but also defined subnets - this is now allowed by tinc'
+  network_mode = network['network'] && network['network']['mode']
+  network_mode ||= 'router' # Default tinc mode value
+
+  if !Array(network['host']['subnets']).empty? && network_mode == 'switch'
+    raise 'You defined switch as your mode, but also defined subnets - ' \
+          'this is now allowed by tinc'
   end
 
   directory "/etc/tinc/#{network_name}"
@@ -27,12 +56,15 @@ node['tincvpn']['networks'].each do |network_name, network|
 
   if network['host']['name'] && network['host']['name'] != node['hostname']
     Chef::Log.warn(
-      "Host name from tincvpn attributes (#{network['host']['name'].inspect}) " \
-      "differs with node's hostname (#{node['hostname'].inspect})."
+      "The hostname #{network['host']['name'].inspect} from tincvpn " \
+      "attributes differs with node's hostname " \
+      "(#{node['hostname'].inspect})."
     )
   end
 
-  local_host_name = (network['host']['name'] || node['hostname']).gsub('-', '_')
+  local_host_name = network['host']['name'] || node['hostname']
+  local_host_name = local_host_name.gsub('-', '_')
+
   local_host_path = "/etc/tinc/#{network_name}/hosts/#{local_host_name}"
   priv_key_location = "/etc/tinc/#{network_name}/rsa_key.priv"
 
@@ -46,12 +78,12 @@ node['tincvpn']['networks'].each do |network_name, network|
     end
   end
 
-
-  # we use the tinc tool to generate the priv and public key, since openssl with
-  # public key is kind of complicated with chef we remove the tinc.conf before
-  # we generate, since otherwise the public key will not be saved in
-  # /etc/tinc/#{network_name}/rsa_key.pub but rather in the hosts/<localname>
-  # file - and we do not want that for simplicity of extraction
+  # we use the tinc tool to generate the priv and public key, since openssl
+  # with public key is kind of complicated with chef we remove the tinc.conf
+  # before we generate, since otherwise the public key will not be saved in
+  # /etc/tinc/#{network_name}/rsa_key.pub but rather in
+  # the hosts/<localname> file - and we do not want that for
+  # simplicity of extraction
   execute "generate-#{network_name}-keys" do
     command "rm -f #{local_host_path} && rm -f /etc/tinc/#{network_name}/tinc.conf && (yes | tincd  -n #{network_name} -K4096)"
     creates priv_key_location
@@ -61,8 +93,9 @@ node['tincvpn']['networks'].each do |network_name, network|
 
   # local host entry in hosts/
   # thats basically "us in the hosts file" - this is needed and mandaory
-  host_addr = node['fqdn']
-  host_addr = network['host']['address'] unless network['host']['address'].nil?
+  # Takes the host address from the attributes if defined, otherwise takes
+  # the automatic fqdn attribute (ohai)
+  host_addr = network['host']['address'] || node['fqdn']
   template local_host_path do
     source 'host.erb'
     variables(
@@ -82,8 +115,9 @@ node['tincvpn']['networks'].each do |network_name, network|
     action :nothing
   end
 
-  # tinc up/down - mainly defining our tunnel network and our tunnel network address
-  %w{up down}.each do |action|
+  # tinc up/down - mainly defining our tunnel network and our tunnel network
+  # address
+  %w[up down].each do |action|
     template "/etc/tinc/#{network_name}/tinc-#{action}" do
       source "tinc-#{action}.erb"
       mode '0755'
@@ -96,9 +130,10 @@ node['tincvpn']['networks'].each do |network_name, network|
     end
   end
 
-  ########################################################################################
-  ######## put all the remote hosts in place we can connect to, search for the nodes in chef
-  ########################################################################################
+  ##########################################################################
+  # put all the remote hosts in place we can connect to,
+  # search for the nodes in chef
+  ##########################################################################
   # all the remote hosts
   hosts_connect_to = []
   # any other node having a public key and joined the same network
@@ -107,14 +142,16 @@ node['tincvpn']['networks'].each do |network_name, network|
   peers.each do |peer|
     host_name = peer['hostname']
 
-    # skip if the node found is actually then node we run on, since that host file has been written already above
+    # Skip if the node found is actually the node we run on,
+    # since that host file has been written already above
     # and the values in the search would be outdated anyway
     next if host_name == local_host_name
 
     # check which hosts this peers defined to connect to
     defined_connect_to = network['host']['connect_to']
 
-    # filter hosts we did not want to connect to on this peer (if the whitelist exists)
+    # Filter hosts we did not want to connect to on this peer
+    # (if the whitelist exists)
     next if !Array(defined_connect_to).empty? && !Array(defined_connect_to).include?(host_name)
 
     host_addr = peer['fqdn']
@@ -137,9 +174,9 @@ node['tincvpn']['networks'].each do |network_name, network|
     hosts_connect_to << host_name.gsub('-', '_')
   end
 
-  ########################################################################################
-  ######## deploy our node network configuration
-  ########################################################################################
+  ##########################################################################
+  # deploy our node network configuration
+  ##########################################################################
   template "/etc/tinc/#{network_name}/tinc.conf" do
     source 'tinc.conf.erb'
     variables(
@@ -147,12 +184,12 @@ node['tincvpn']['networks'].each do |network_name, network|
       port: network['network'] && network['network']['port'] || 655,
       interface: network['network'] && network['network']['interface'],
       hosts_connect_to: hosts_connect_to,
-      mode: avahi_zeroconf_enabled ? 'switch' : network['network'] && network['network']['mode']
+      mode: avahi_zeroconf_enabled ? 'switch' : network_mode
     )
     notifies :reload, 'service[tinc]', :delayed
   end
 
-  # we need this for systemd configuration starting from debian-stretch
+  # We need this for systemd configuration starting from debian-stretch
   # /etc/tinc/nets.boot are no longer working / is ignored, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=841052#27
   if node['platform'] == 'debian'
     version = shell_out('cat /etc/os-release | grep "VERSION="').stdout

--- a/templates/host.erb
+++ b/templates/host.erb
@@ -2,7 +2,7 @@ Address = <%= @address %> <%= @port %>
 Cipher=aes-256-cbc
 Digest=sha256
 
-<% @subnets.sort.each do |subnet| %>
+<% Array(@subnets).sort.each do |subnet| %>
 Subnet = <%= subnet %>
 <% end -%>
 

--- a/test/fixtures/nodes/tinccustomnode1.tincvpn.vagrant.json
+++ b/test/fixtures/nodes/tinccustomnode1.tincvpn.vagrant.json
@@ -1,0 +1,24 @@
+{
+  "name": "tinccustomnode1.tincvpn.vagrant",
+  "normal": {
+    "tincvpn": {
+      "networks": {
+        "custom": {
+          "network": {
+            "port": 651
+          },
+          "host": {
+            "name": "tinccustomnode1",
+            "address": "15.0.0.1",
+            "subnets": [ "10.1.0.0/24", "172.1.0.0/16"],
+            "pubkey": "test-pubkey1"
+          }
+        }
+      }
+    }
+  },
+  "automatic": {
+    "hostname": "tinccustomnode1",
+    "fqdn": "tinccustomnode1.tincvpn.vagrant"
+  }
+}

--- a/test/integration/custom_network/tinc_spec.rb
+++ b/test/integration/custom_network/tinc_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+describe package('tinc') do
+  it { should be_installed }
+end
+
+describe file('/etc/tinc/nets.boot') do
+  its('content') { should_not match 'default' }
+  its('content') { should match 'custom' }
+end
+
+describe file('/etc/tinc/default/tinc.conf') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/tinc.conf') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/tinc-up') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/tinc-up') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/tinc-down') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/tinc-down') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/rsa_key.priv') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/rsa_key.priv') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/rsa_key.pub') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/rsa_key.pub') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/hosts') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/hosts/tinccustomnode1') do
+  it { should exist }
+end
+
+# we excluded that one in our attributes
+describe file('/etc/tinc/default/hosts/tincnode4') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/hosts/tincnode4') do
+  it { should_not exist }
+end
+
+# thats our own host
+describe file('/etc/tinc/default/hosts/tincvpn3') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/custom/hosts/tincvpn3') do
+  it { should exist }
+end

--- a/test/integration/default/tinc_spec.rb
+++ b/test/integration/default/tinc_spec.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 describe package('tinc') do
   it { should be_installed }
 end
 
 describe file('/etc/tinc/nets.boot') do
-  its('content') { should match "default" }
+  its('content') { should match 'default' }
 end
 
 describe file('/etc/tinc/default/tinc.conf') do
   it { should exist }
-  its('content') { should match "Port = 655" }
-  its('content') { should match "ConnectTo = tincnode1" }
-  its('content') { should match "ConnectTo = tincnode2" }
-  its('content') { should_not match "ConnectTo = tincnode4" }
-  its('content') { should match "Mode = router" }
-  its('content') { should match "Name = tincvpn3" }
+  its('content') { should match 'Port = 655' }
+  its('content') { should match 'ConnectTo = tincnode1' }
+  its('content') { should match 'ConnectTo = tincnode2' }
+  its('content') { should_not match 'ConnectTo = tincnode4' }
+  its('content') { should match 'Mode = router' }
+  its('content') { should match 'Name = tincvpn3' }
 end
 
 describe file('/etc/tinc/default/tinc-up') do
@@ -23,7 +25,7 @@ end
 
 describe file('/etc/tinc/default/tinc-down') do
   it { should exist }
-  its('content') { should match "ifconfig [$]INTERFACE down" }
+  its('content') { should match 'ifconfig [$]INTERFACE down' }
 end
 
 describe file('/etc/tinc/default/rsa_key.priv') do
@@ -41,7 +43,7 @@ describe file('/etc/tinc/default/hosts/tincnode1') do
   its('content') { should match "Address = 15\.0\.0\.1 651" }
   its('content') { should match "10\.1\.0\.0/24" }
   its('content') { should match "172\.1\.0\.0/16" }
-  its('content') { should match "test-pubkey1" }
+  its('content') { should match 'test-pubkey1' }
 end
 
 describe file('/etc/tinc/default/hosts/tincnode2') do
@@ -49,7 +51,7 @@ describe file('/etc/tinc/default/hosts/tincnode2') do
   its('content') { should match "Address = 15\.0\.0\.2 652" }
   its('content') { should match "10\.2\.0\.0/24" }
   its('content') { should match "172\.2\.0\.0/16" }
-  its('content') { should match "test-pubkey2" }
+  its('content') { should match 'test-pubkey2' }
 end
 
 # we excluded that one in our attributes
@@ -62,6 +64,6 @@ describe file('/etc/tinc/default/hosts/tincvpn3') do
   it { should exist }
   its('content') { should match "10\.3\.0\.0/24" }
   its('content') { should match "172\.3\.0\.0/16" }
-  its('content') { should match 'BEGIN RSA PUBLIC KEY'}
-  its('content') { should match 'END RSA PUBLIC KEY'}
+  its('content') { should match 'BEGIN RSA PUBLIC KEY' }
+  its('content') { should match 'END RSA PUBLIC KEY' }
 end


### PR DESCRIPTION
1. This PR updates the cookbook recipe in order to get the hostname from Ohai instead of setting it manually.
2. It also update the kitchen YAML files in order to align them (alphabetic ordering the nodes, removing single and double quotes)
3. It sets a default value of the port to 655 if not defined in the attributes
4. Finally it replaces everywhere where it is possible `node['tincvpn']['networks'][network_name]` by the `network` variable as it was already done at few places (aligning code)