### PR TITLE
Restarts the tinc service instead of reload (Closes #16)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -179,7 +179,7 @@ node['tincvpn']['networks'].each do |network_name, network|
         port: host_port,
         subnets: avahi_zeroconf_enabled ? [] : peer['tincvpn']['networks'][network_name]['host']['subnets']
       )
-      notifies :reload, 'service[tinc]', :delayed
+      notifies :restart, 'service[tinc]', :delayed
     end
 
     # add all hosts to our connectTo list, except ourselfs


### PR DESCRIPTION
Reloading the tinc service doesn't seem to be enough in order to get it refreshing its host identity database, which makes the nodes unable to communicate together.
This commit replaces the service action "reload" by "restart" which forces Tinc to refresh its dabatabase and fixes communication issue