### PR TITLE
Implements automatic IP address assignment from a given IP address range

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -43,6 +43,9 @@ suites:
               subnets:
                 - 10.3.0.0/24
                 - 172.3.0.0/16
+            network:
+              tunneladdr: 172.25.0.1
+              tunnelnetmask: 255.255.255.0
     run_list:
       - recipe[tincvpn::default]
     verifier:
@@ -110,6 +113,9 @@ suites:
               subnets:
                 - 10.3.0.0/24
                 - 172.3.0.0/16
+            network:
+              tunneladdr: 172.25.0.1
+              tunnelnetmask: 255.255.255.0
     run_list:
       - recipe[tincvpn::default]
     verifier:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -40,6 +40,9 @@ suites:
               subnets:
                 - 10.3.0.0/24
                 - 172.3.0.0/16
+            network:
+              tunneladdr: 172.25.0.1
+              tunnelnetmask: 255.255.255.0
     run_list:
       - recipe[tincvpn::default]
     verifier:
@@ -107,6 +110,9 @@ suites:
               subnets:
                 - 10.3.0.0/24
                 - 172.3.0.0/16
+            network:
+              tunneladdr: 172.25.0.1
+              tunnelnetmask: 255.255.255.0
     run_list:
       - recipe[tincvpn::default]
     verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,9 @@ suites:
               subnets:
                 - 10.3.0.0/24
                 - 172.3.0.0/16
+            network:
+              tunneladdr: 172.25.0.1
+              tunnelnetmask: 255.255.255.0
     run_list:
       - recipe[tincvpn::default]
     verifier:
@@ -97,6 +100,9 @@ suites:
               subnets:
                 - 10.3.0.0/24
                 - 172.3.0.0/16
+            network:
+              tunneladdr: 172.25.0.1
+              tunnelnetmask: 255.255.255.0
     run_list:
       - recipe[tincvpn::default]
     verifier:
@@ -137,3 +143,15 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/avahi_zeroconf
+  - name: default-with-ip-range
+    attributes:
+      tincvpn:
+        networks:
+          default:
+            network:
+              iprange: 10.0.0.0/24
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/iprange

--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -4,13 +4,22 @@
 default[:tincvpn][:networks]['default'][:network][:mode] = 'router'
 default[:tincvpn][:networks]['default'][:network][:port] = 655
 # Set interface if needed
-default[:tincvpn][:networks]['default'][:network][:interface] = nil  # Ex. 'tun'
-# that is the virtual network the tinc mesh nodes connect to (not your LAN you will join/offer, see subnets)
-default[:tincvpn][:networks]['default'][:network][:tunneladdr] = '172.25.0.1'
-default[:tincvpn][:networks]['default'][:network][:tunnelnetmask] = '255.255.255.0'
+default[:tincvpn][:networks]['default'][:network][:interface] = nil # Ex. 'tun'
+# That is the virtual network the tinc mesh nodes connect to
+# (not your LAN you will join/offer, see subnets)
+# IP address (For example 172.25.0.1)
+default[:tincvpn][:networks]['default'][:network][:tunneladdr] = nil
+# Netmask (For example 255.255.255.0)
+default[:tincvpn][:networks]['default'][:network][:tunnelnetmask] = nil
+# IP range to be used in order to auto-set the tunneladdr and tunnelnetmask
+# attributes.
+# This has no effect if tunneladdr and tunnelnetmask are already set.
+# The value should be something like 10.0.0.0/24.
+default[:tincvpn][:networks]['default'][:network][:iprange] = nil
 # optional, you can to set this to a name of the host, like node1 or whatever
 default[:tincvpn][:networks]['default'][:host][:name] = nil
-# which nodes this host should be able to connect to. If you skip, any node in this network will be a connect target
+# which nodes this host should be able to connect to.
+# If you skip, any node in this network will be a connect target
 default[:tincvpn][:networks]['default'][:host][:connect_to] = []
 # define the subnets you want to share of your networks, like you LAN or whatever
 default[:tincvpn][:networks]['default'][:host][:subnets] = []
@@ -19,5 +28,8 @@ default[:tincvpn][:networks]['default'][:host][:address] = nil
 
 # use zeroconf with automatic ip and dns management
 # see https://www.tinc-vpn.org/examples/zeroconf-ip-and-dns/ for details.
-# When using this option network mode always switch and subnets are always empty array
+# When using this option network mode always switch
+# and subnets are always empty array.
+# Avahi will automatically assign a Link-local address to your nodes.
+# (https://en.wikipedia.org/wiki/Link-local_address)
 default[:tincvpn][:networks]['default'][:host][:avahi_zeroconf_enabled] = false

--- a/test/integration/iprange/tinc_spec.rb
+++ b/test/integration/iprange/tinc_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+describe file('/etc/tinc/default/tinc-up') do
+  it { should exist }
+  its('content') { should match /ifconfig \$INTERFACE 10\.0\.0\.\d+ netmask 255\.255\.255\.0/ }
+end
+
+describe file('/etc/tinc/default/hosts/tincvpn3') do
+  it { should exist }
+  its('content') { should match /Address = 10\.0\.2\.15 655/ }
+  its('content') { should match /Subnet = 10\.0\.0\.\d+\/32/ }
+end


### PR DESCRIPTION
This commit implements a simple IP address assignment mechanism which will takes randomly IP addresses from the `default[:tincvpn][:networks]['default'][:network][:iprange]` attribute until it finds a free one.

I'm running this change since 2 months on my nodes and all works fine so far.