### PR TITLE
Adds support for environments/policy groups

### DIFF
--- a/.kitchen.docker.custom-environment.yml
+++ b/.kitchen.docker.custom-environment.yml
@@ -1,0 +1,68 @@
+---
+# this is still very early - it seems to be significanly slower then `docken`
+# and yet seems to fail connecting using SSH when we start systemd
+# currently this is not working but it is WIP
+#
+# The aim of this file is to test the Tinc cookbook using a Chef environment
+# or Chef Policy group.
+# This means all the suites, running from this file, are running with
+# the `chef_environment` being "kitchen" (while with the other kitchen files
+# `chef_environment` is "_default")
+
+driver:
+  cap_add:
+    - SYS_ADMIN
+  disable_upstart: false
+  hostname: tincvpn3
+  name: docker
+  privileged: yes
+  provision_command:
+    - apt-get install systemd -y
+  run_command: /bin/systemd
+  socket: unix:///var/run/docker.sock
+
+provisioner:
+  always_update_cookbooks: true
+  chef_license: accept
+  client_rb:
+    environment: kitchen
+  environments_path: test/fixtures/environments
+  log_level: warn # debug, info, warn, error, and fatal
+  name: chef_zero
+  nodes_path: test/fixtures/kitchen_env_nodes
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: debian-9
+    driver_config:
+      image: debian:stretch
+  - name: debian-10
+    driver_config:
+      image: debian:buster
+
+suites:
+  - name: two-env-with-different-config
+    attributes:
+      # The expected config to be applied
+      kitchen:
+        tincvpn:
+          networks:
+            infravpn:
+              network:
+                iprange: 10.0.0.0/24
+                mode: switch
+      # Another config that should not be applied at all
+      the_other_env:
+        tincvpn:
+          networks:
+            infravpn:
+              network:
+                iprange: 10.0.1.0/24
+                mode: switch
+    run_list:
+      - recipe[tincvpn::default]
+    verifier:
+      inspec_tests:
+        - test/integration/custom_environments/two_env_with_different_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ services:
 env:
   - KITCHEN_YAML=.kitchen.dokken.yml
   - KITCHEN_YAML=.kitchen.docker.yml
+  - KITCHEN_YAML=.kitchen.docker.custom-environment.yml
 
 before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk
 

--- a/test/fixtures/environments/kitchen.json
+++ b/test/fixtures/environments/kitchen.json
@@ -1,0 +1,9 @@
+{
+  "name": "kitchen",
+  "description": "Custom Kitchen environment",
+  "cookbook_versions": {},
+  "json_class": "Chef::Environment",
+  "chef_type": "environment",
+  "default_attributes": {},
+  "override_attributes": {}
+}

--- a/test/fixtures/kitchen_env_nodes/tincnode1.tincvpn.vagrant.json
+++ b/test/fixtures/kitchen_env_nodes/tincnode1.tincvpn.vagrant.json
@@ -1,0 +1,26 @@
+{
+  "name": "infranode1.tincvpn.vagrant",
+  "chef_environment": "kitchen",
+  "normal": {
+    "tincvpn": {
+      "networks": {
+        "infravpn": {
+          "network": {
+            "tunneladdr": "10.0.0.29",
+            "tunnelnetmask": "255.255.255.0"
+          },
+          "host": {
+            "subnets": [
+              "10.0.0.29/32"
+            ],
+            "pubkey": "\ntest-pubkey1\n"
+          }
+        }
+      }
+    }
+  },
+  "automatic": {
+    "hostname": "infranode1",
+    "fqdn": "infranode1.tincvpn.vagrant"
+  }
+}

--- a/test/fixtures/nodes/tinccustomnode1.tincvpn.vagrant.json
+++ b/test/fixtures/nodes/tinccustomnode1.tincvpn.vagrant.json
@@ -10,7 +10,7 @@
           "host": {
             "name": "tinccustomnode1",
             "address": "15.0.0.1",
-            "subnets": [ "10.1.0.0/24", "172.1.0.0/16"],
+            "subnets": ["10.1.0.0/24", "172.1.0.0/16"],
             "pubkey": "test-pubkey1"
           }
         }

--- a/test/fixtures/nodes/tincnode1.tincvpn.vagrant.json
+++ b/test/fixtures/nodes/tincnode1.tincvpn.vagrant.json
@@ -10,7 +10,7 @@
           "host": {
             "name": "tincnode1",
             "address": "15.0.0.1",
-            "subnets": [ "10.1.0.0/24", "172.1.0.0/16"],
+            "subnets": ["10.1.0.0/24", "172.1.0.0/16"],
             "pubkey": "test-pubkey1"
           }
         }

--- a/test/fixtures/nodes/tincnode2.tincvpn.vagrant.json
+++ b/test/fixtures/nodes/tincnode2.tincvpn.vagrant.json
@@ -10,7 +10,7 @@
           "host": {
             "name": "tincnode2",
             "address": "15.0.0.2",
-            "subnets": [ "10.2.0.0/24", "172.2.0.0/16"],
+            "subnets": ["10.2.0.0/24", "172.2.0.0/16"],
             "pubkey": "test-pubkey2"
           }
         }

--- a/test/fixtures/nodes/tincnode4.tincvpn.vagrant.json
+++ b/test/fixtures/nodes/tincnode4.tincvpn.vagrant.json
@@ -10,7 +10,7 @@
           "host": {
             "name": "tincnode4",
             "address": "15.0.0.4",
-            "subnets": [ "10.4.0.0/24", "172.4.0.0/16"],
+            "subnets": ["10.4.0.0/24", "172.4.0.0/16"],
             "pubkey": "test-pubkey4"
           }
         }

--- a/test/integration/custom_environments/two_env_with_different_config/tinc_spec.rb
+++ b/test/integration/custom_environments/two_env_with_different_config/tinc_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe package('tinc') do
+  it { should be_installed }
+end
+
+describe file('/etc/tinc/nets.boot') do
+  its('content') { should_not match 'default' }
+  its('content') { should match 'infravpn' }
+end
+
+describe file('/etc/tinc/default/tinc.conf') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/tinc.conf') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/tinc-up') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/tinc-up') do
+  it { should exist }
+  its('content') { should match %r{10.0.0.\d+ netmask 255.255.255.0} }
+end
+
+describe file('/etc/tinc/default/tinc-down') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/tinc-down') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/rsa_key.priv') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/rsa_key.priv') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/rsa_key.pub') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/rsa_key.pub') do
+  it { should exist }
+end
+
+describe file('/etc/tinc/default/hosts') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/hosts/infranode1') do
+  it { should exist }
+end
+
+# we excluded that one in our attributes
+describe file('/etc/tinc/default/hosts/tincnode4') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/hosts/tincnode4') do
+  it { should_not exist }
+end
+
+# thats our own host
+describe file('/etc/tinc/default/hosts/tincvpn3') do
+  it { should_not exist }
+end
+
+describe file('/etc/tinc/infravpn/hosts/tincvpn3') do
+  it { should exist }
+end


### PR DESCRIPTION
This pull request takes the environment or policy group in order to filter the attributes, but also improves the coherence of the recipe by searching peers from the same environment/policy group.

My use case for this change is to define a different IP range per clusters so that my East cluster has one range, and my West cluster another one, and it work really well.