### PR TITLE
Upgrades the openssl cookbook to 8.5.5 (Closes #34)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,6 @@ chef_version      '>= 13'
   supports os
 end
 
-depends          'openssl', '= 4.4.0'
+depends          'openssl', '~> 8.5.5'
 source_url       'https://github.com/EugenMayer/chef-tinc-cookbook'
 issues_url       'https://github.com/EugenMayer/chef-tinc-cookbook/issues'


### PR DESCRIPTION
This PR upgrades the openssl cookbook to version 8.5.5 as discussed in #34.