### PR TITLE
Adds an attribue to allow disabling service restart

### DIFF
--- a/attributes/tincvpn.rb
+++ b/attributes/tincvpn.rb
@@ -33,3 +33,7 @@ default[:tincvpn][:networks]['default'][:host][:address] = nil
 # Avahi will automatically assign a Link-local address to your nodes.
 # (https://en.wikipedia.org/wiki/Link-local_address)
 default[:tincvpn][:networks]['default'][:host][:avahi_zeroconf_enabled] = false
+
+# In the case you're experiencing issues when the service is restarted, you can
+# prevent the cookbook from restarting by setting this attribute to `false`.
+default[:tincvpn][:allow_service_restart] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,7 @@ package %w(tinc bridge-utils)
 
 service 'tinc' do
   action %i[enable start]
+  only_if { node.normal['tincvpn']['allow_service_restart'] }
 end
 
 # As this cookbook is updating the node's network (adding a new network

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -254,7 +254,7 @@ Array(env_attributes['networks']).each do |network_name, network|
   # the automatic ipaddress attribute (ohai)
   host_addr = network['host'] && network['host']['address'] || node['ipaddress']
 
-  subnets = avahi_zeroconf_enabled ? [] : network_host_subnets
+  subnets = avahi_zeroconf_enabled ? [] : (network_host_subnets || node.normal['tincvpn']['networks'][network_name]['host']['subnets'])
 
   Chef::Log.info "Updating #{local_host_path} with subnets '#{subnets.inspect}'"
   template local_host_path do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -216,7 +216,7 @@ Array(env_attributes['networks']).each do |network_name, network|
   priv_key_location = "/etc/tinc/#{network_name}/rsa_key.priv"
 
   avahi_zeroconf_enabled = network['host'] && network['host']['avahi_zeroconf_enabled']
-  Chef::Log.info "Avahi is #{avahi_zeroconf_enabled ? 'en' : 'dis'}able"
+  Chef::Log.info "Avahi is #{avahi_zeroconf_enabled ? 'en' : 'dis'}abled"
 
   if avahi_zeroconf_enabled
     package %w(avahi-daemon avahi-utils avahi-autoipd)
@@ -254,7 +254,9 @@ Array(env_attributes['networks']).each do |network_name, network|
   # the automatic ipaddress attribute (ohai)
   host_addr = network['host'] && network['host']['address'] || node['ipaddress']
 
-  subnets = avahi_zeroconf_enabled ? [] : (network_host_subnets || node.normal['tincvpn']['networks'][network_name]['host']['subnets'])
+  node_subnets = node.normal['tincvpn']['networks'][network_name]['host']['subnets']
+  Chef::Log.info "node_subnets: #{node_subnets.inspect}"
+  subnets = avahi_zeroconf_enabled ? [] : (network_host_subnets || node_subnets)
 
   Chef::Log.info "Updating #{local_host_path} with subnets '#{subnets.inspect}'"
   template local_host_path do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -256,7 +256,7 @@ Array(env_attributes['networks']).each do |network_name, network|
 
   node_subnets = node.normal['tincvpn']['networks'][network_name]['host']['subnets']
   Chef::Log.info "node_subnets: #{node_subnets.inspect}"
-  subnets = avahi_zeroconf_enabled ? [] : (network_host_subnets || node_subnets)
+  subnets = avahi_zeroconf_enabled ? [] : (network_host_subnets.empty? ? node_subnets : network_host_subnets)
 
   Chef::Log.info "Updating #{local_host_path} with subnets '#{subnets.inspect}'"
   template local_host_path do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,7 +34,7 @@ env_attributes = if node.environment == '_default'
                    else
                      Chef::Log.warn 'tinc: The node has no Tinc attribute ' \
                                     "for the #{node.environment.inspect} " \
-                                    "environment/policy group, therefore " \
+                                    'environment/policy group, therefore ' \
                                     'this cookbook will not do anything.'
 
                      {}
@@ -243,7 +243,7 @@ Array(env_attributes['networks']).each do |network_name, network|
             "&& rm -f /etc/tinc/#{network_name}/tinc.conf " \
             "&& (yes | tincd  -n #{network_name} -K4096)"
     creates priv_key_location
-    not_if { File.exist?(priv_key_location) }
+    not_if { ::File.exist?(priv_key_location) }
   end
 
   # local host entry in hosts/
@@ -382,7 +382,8 @@ Array(env_attributes['networks']).each do |network_name, network|
   # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=841052#27
   service "tinc@#{network_name}" do
     action %i[enable start]
-    only_if { File.exist?('/bin/systemd') }
+    only_if { node.normal['tincvpn']['allow_service_restart'] }
+    only_if { ::File.exist?('/bin/systemd') }
   end
 end
 


### PR DESCRIPTION
The goal of this PR is to allow disabling service restart.

We are facing here the case where restarting the service is breaking the Tinc service, so we'd like to disable auto restart. 